### PR TITLE
Fix graphicspath in main.tex. Fix hyperlink in acks.tex

### DIFF
--- a/acks.tex
+++ b/acks.tex
@@ -1,6 +1,6 @@
 \section{Acknowledgments}
 This is the acknowledgements section.
 Include acknowledgements for relevant funding sources and contributors for
-this work. Review the [how-to-acknowledge](https://drive.google.com/open?id=1VybV0oMPiqpInTwgO0ICq0EC4AL_fGj-zbXGJAhRiVU)
+this work. Review the \href{https://drive.google.com/open?id=1VybV0oMPiqpInTwgO0ICq0EC4AL_fGj-zbXGJAhRiVU}{how-to-acknowledge}
 document for the appropriate text, which changes frequently as grants and people
 come and go.

--- a/main.tex
+++ b/main.tex
@@ -30,7 +30,7 @@
 %% Special typesetting for Cyclus
 \newcommand{\Cyclus}{\textsc{Cyclus}\xspace}%
 \newcommand{\Cycamore}{\textsc{Cycamore}\xspace}%
-\graphicspath{images/}
+\graphicspath{{images/}}
 
 % tikz %
 \usepackage{tikz}


### PR DESCRIPTION
The graphicspath in latex files requires an additional pair of curly braces around each entry.

The hyperlink formatting was wrong in acks.tex.