### PR TITLE
Updates README.md with formatting instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # journal-article-template
-=======
-
 This repository contains a template for journal
 articles published by Elsevier. This template
 repository is largely derived from the github

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ of revisions should be covered in a separate TeX
 file.
 
 # To review
-The ``elsarticle`` format comes with convenient options for viewing.
+The ``elsarticle`` format supports convenient options for viewing.
+
 To view the article in a "review" format, modify the first line of the
 ``main.tex`` file so that it reads
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,21 @@ comments and the corresponding edits. Each new round
 of revisions should be covered in a separate TeX
 file.
 
+# To review
+The ``elsarticle`` format comes with convenient options for viewing.
+To view the article in a "review" format, modify the first line of the
+``main.tex`` file so that it reads
+
+``\documentclass[review]{elsarticle}``
+
+To view the article in a "final print" format, modify the first line of
+``main.tex`` file so that it reads
+
+``\documentclass[3p, twocolumn]{elsarticle}``
+
+``elsarticle`` supports other formats that can be read about
+[here](https://www.elsevier.com/__data/assets/pdf_file/0008/56843/elsdoc-1.pdf)
+
 # To compile
 Run `make` after making appropriate edits to the
 `main.tex` file and adding content to other tex files as needed.


### PR DESCRIPTION
This PR adds instructions to change the viewing format of the final ``pdf``. Default is ``[review]`` but ``elsarticle`` supports other styles (like final print style). 
I also included a link to the Elsevier style documentation and cleaned the ``README.md`` file by deleting unnecessary ``========`` from the top. 